### PR TITLE
chore: add `minify` as `postbuild` hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[Makefile]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 prepare:
-	which git
-	which make
-	which yay
+	which go
+	which pkg
+	which apt-get
 	# curl -sf https://gobinaries.com/tdewolff/minify/cmd/minify | sh
 	# minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ prepare:
 	curl -L https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz > minify.tar.gz
 	tar -xf minify.tar.gz
 	./minify -h
-	ln -s minify /usr/local/bin
+	echo $(PATH)
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 prepare:
-	curl -sf https://gobinaries.com/tdewolff/minify/cmd/minify | sh
-	minify --version
+	which git
+	which make
+	which yay
+	# curl -sf https://gobinaries.com/tdewolff/minify/cmd/minify | sh
+	# minify --version
 
 build: prepare
 	npm run build -- --minify

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ prepare:
 	curl -L https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz > minify.tar.gz
 	tar -xf minify.tar.gz
 	./minify -h
+	mv minify /opt/buildhome/.
+	export PATH=$(PATH):/opt/buildhome/minify
 	echo $(PATH)
 	which minify
 	minify --version

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,5 @@ download:
 
 build: download
 	npm run build
-	cat public/index.html
-	minify -r public -o .
+	./minify -r public -o .
 	cat public/index.html

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 prepare:
 	echo "Cloning tdewolff/minify source"
 	git clone --depth 1 https://github.com/tdewolff/minify.git
-	$(MAKE) install -C minify --ignore-errors
+	@-$(MAKE) --ignore-errors install -C minify
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 prepare:
 	echo "Cloning tdewolff/minify source"
 	git clone --depth 1 https://github.com/tdewolff/minify.git
-	@-$(MAKE) --ignore-errors install -C minify
+	@-$(MAKE) install -C minify -k
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # https://github.com/tdewolff/minify/tree/master/cmd/minify#installation
 prepare:
-	mkdir $HOME/src
-	cd $HOME/src
+	mkdir $(HOME)/src
+	cd $(HOME)/src
 	git clone --depth 1 https://github.com/tdewolff/minify.git
 	cd minify
 	make install

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,8 @@
 # https://github.com/tdewolff/minify/tree/master/cmd/minify#installation
+# NOTE: build pipeline prevents `cd` action
 prepare:
-	mkdir $(HOME)/src
-	cd $(HOME)/src
 	git clone --depth 1 https://github.com/tdewolff/minify.git
-	ls -alh
-	ls -alh minify
-	cd minify
-	ls -alh
-	go install ./cmd/minify
+	go install ./minify/cmd/minify
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,12 @@
 # https://github.com/tdewolff/minify/tree/master/cmd/minify#installation
 # NOTE: build pipeline prevents `cd` action
 
-prepare:
-	which go
-	which git
+download:
 	curl -L https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz > minify.tar.gz
 	tar -xf minify.tar.gz
-	./minify -h
-	mv minify /opt/buildhome/.
-	export PATH=$(PATH):/opt/buildhome/minify
-	echo $(PATH)
-	which minify
-	minify --version
 
-build: prepare
-	npm run build -- --minify
+build: download
+	npm run build
+	cat public/index.html
+	minify -r public -o .
+	cat public/index.html

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,3 @@ download:
 build: download
 	npm run build
 	./minify -r public -o .
-	cat public/index.html

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ prepare:
 	which git
 	curl -L https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz > minify.tar.gz
 	tar -xf minify.tar.gz
-	ls -alh
+	ls /usr/local
+	ls /usr/local/bin
+	ls /usr/bin
+	./minify -h
+	ln -s minify
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 prepare:
 	echo "Cloning tdewolff/minify source"
 	git clone --depth 1 https://github.com/tdewolff/minify.git
-	-@$(MAKE) install -C minify
+	$(MAKE) install -C minify --ignore-errors
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@
 prepare:
 	echo "Cloning tdewolff/minify source"
 	git clone --depth 1 https://github.com/tdewolff/minify.git
+	ls -alh minify
 	@-$(MAKE) install -C minify -k
 	which minify
+	ls -alh minify
 	minify --version
 
 build: prepare

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # NOTE: build pipeline prevents `cd` action
 prepare:
 	git clone --depth 1 https://github.com/tdewolff/minify.git
-	go install ./minify/cmd/minify
+	$(MAKE) install -C minify
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ prepare:
 	mkdir $(HOME)/src
 	cd $(HOME)/src
 	git clone --depth 1 https://github.com/tdewolff/minify.git
+	ls -alh
+	ls -alh minify
 	cd minify
 	ls -alh
 	go install ./cmd/minify

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # https://github.com/tdewolff/minify/tree/master/cmd/minify#installation
 # NOTE: build pipeline prevents `cd` action
 
+FLAGS=v2.9.24
 FLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}'" -trimpath
 ENVS=GO111MODULES=on CGO_ENABLED=0
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,8 @@ prepare:
 	which git
 	curl -L https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz > minify.tar.gz
 	tar -xf minify.tar.gz
-	ls /usr/local
-	ls /usr/local/bin
-	ls /usr/bin
 	./minify -h
-	ln -s minify
+	ln -s minify ~/local/bin
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ prepare:
 	cd $(HOME)/src
 	git clone --depth 1 https://github.com/tdewolff/minify.git
 	cd minify
-	make install
+	go install ./cmd/minify
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
+# https://github.com/tdewolff/minify/tree/master/cmd/minify#installation
 prepare:
-	which go
-	which pkg
-	which apt-get
-	# curl -sf https://gobinaries.com/tdewolff/minify/cmd/minify | sh
-	# minify --version
+	mkdir $HOME/src
+	cd $HOME/src
+	git clone --depth 1 https://github.com/tdewolff/minify.git
+	cd minify
+	make install
+	which minify
+	minify --version
 
 build: prepare
 	npm run build -- --minify

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # https://github.com/tdewolff/minify/tree/master/cmd/minify#installation
 # NOTE: build pipeline prevents `cd` action
 
-FLAGS=v2.9.24
+VERSION=v2.9.24
 FLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}'" -trimpath
 ENVS=GO111MODULES=on CGO_ENABLED=0
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+prepare:
+	curl -sf https://gobinaries.com/tdewolff/minify/cmd/minify | sh
+	minify --version
+
+build:
+	npm run build -- --minify

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,10 @@
 # NOTE: build pipeline prevents `cd` action
 
 prepare:
-	echo "Cloning tdewolff/minify source"
-	git clone --depth 1 https://github.com/tdewolff/minify.git
-	ls -alh minify
-	@-$(MAKE) install -C minify -k
+	ls -alh
+	curl -sf https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz | sh
+	ls -alh
 	which minify
-	ls -alh minify
 	minify --version
 
 build: prepare

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
 # https://github.com/tdewolff/minify/tree/master/cmd/minify#installation
 # NOTE: build pipeline prevents `cd` action
 
-VERSION=v2.9.24
-FLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}'" -trimpath
-ENVS=GO111MODULES=on CGO_ENABLED=0
-
 prepare:
 	echo "Cloning tdewolff/minify source"
 	git clone --depth 1 https://github.com/tdewolff/minify.git
-	echo "Installing minify dependencies"
-	${ENVS} go install ${FLAGS} ./minify/cmd/minify
+	-@$(MAKE) install -C minify
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ prepare:
 	curl -sf https://gobinaries.com/tdewolff/minify/cmd/minify | sh
 	minify --version
 
-build:
+build: prepare
 	npm run build -- --minify

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 # https://github.com/tdewolff/minify/tree/master/cmd/minify#installation
 # NOTE: build pipeline prevents `cd` action
+
+FLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}'" -trimpath
+ENVS=GO111MODULES=on CGO_ENABLED=0
+
 prepare:
+	echo "Cloning tdewolff/minify source"
 	git clone --depth 1 https://github.com/tdewolff/minify.git
-	$(MAKE) install -C minify
+	echo "Installing minify dependencies"
+	${ENVS} go install ${FLAGS} ./minify/cmd/minify
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ prepare:
 	curl -L https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz > minify.tar.gz
 	tar -xf minify.tar.gz
 	./minify -h
-	ln -s minify ~/local/bin
+	ln -s minify /usr/local/bin
 	which minify
 	minify --version
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@
 # NOTE: build pipeline prevents `cd` action
 
 prepare:
-	ls -alh
-	curl -sf https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz | sh
+	which go
+	which git
+	curl -L https://github.com/tdewolff/minify/releases/download/v2.9.24/minify_linux_amd64.tar.gz > minify.tar.gz
+	tar -xf minify.tar.gz
 	ls -alh
 	which minify
 	minify --version

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ prepare:
 	cd $(HOME)/src
 	git clone --depth 1 https://github.com/tdewolff/minify.git
 	cd minify
+	ls -alh
 	go install ./cmd/minify
 	which minify
 	minify --version


### PR DESCRIPTION
As an alternative to `--minify` argument, since cannot add local binaries to the Pages pipeline